### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/lumina/components/UploadComponent.tsx
+++ b/lumina/components/UploadComponent.tsx
@@ -27,7 +27,9 @@ const UploadComponent: React.FC = () => {
     const file = event.target.files?.[0];
     if (file) {
       const url = URL.createObjectURL(file);
-      setPreviewUrl(url);
+      if (url.startsWith('blob:')) {
+        setPreviewUrl(url);
+      }
 
       // Optional: Bereinigung alter URLs
       return () => URL.revokeObjectURL(url);


### PR DESCRIPTION
Fixes [https://github.com/lumina-rocks/lumina/security/code-scanning/1](https://github.com/lumina-rocks/lumina/security/code-scanning/1)

To fix the problem, we need to ensure that the `previewUrl` is safe to use in the `src` attribute of the `img` tag. One way to do this is to validate the URL before setting it in the state. We can use a regular expression to ensure that the URL is a valid blob URL.

- Validate the `previewUrl` before setting it in the state.
- Update the `handleFileChange` function to include this validation.
- No additional imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
