### PR TITLE
Fix: Amber login

### DIFF
--- a/lumina/components/LoginForm.tsx
+++ b/lumina/components/LoginForm.tsx
@@ -38,7 +38,8 @@ export function LoginForm() {
         const urlParams = new URLSearchParams(window.location.search);
         const amberResponse = urlParams.get('amberResponse');
         if (amberResponse !== null) {
-            localStorage.setItem("pubkey", nip19.decode(amberResponse).data.toString());
+            // localStorage.setItem("pubkey", nip19.npubEncode(amberResponse).toString());
+            localStorage.setItem("pubkey", amberResponse);
             localStorage.setItem("loginType", "amber");
             window.location.href = `/profile/${amberResponse}`;
         }
@@ -53,6 +54,7 @@ export function LoginForm() {
         }
         const intent = `intent:#Intent;scheme=nostrsigner;S.compressionType=none;S.returnType=signature;S.type=get_public_key;S.callbackUrl=http://${hostname}/login?amberResponse=;end`;
         window.location.href = intent;
+        // window.location.href = `nostrsigner:?compressionType=none&returnType=signature&type=get_public_key&callbackUrl=http://${hostname}/login?amberResponse=`;
     }
 
     const handleExtensionLogin = async () => {


### PR DESCRIPTION
This pull request includes changes to the `LoginForm` component in the `lumina` project to modify how the `amberResponse` is processed and to comment out some existing code for potential future use.

Changes to `LoginForm` component:

* Modified the `amberResponse` handling to store the raw response directly in `localStorage` instead of encoding it with `nip19.npubEncode`.
* Commented out an alternative URL redirection method for `nostrsigner` in the `LoginForm` component for potential future use.