### PR TITLE
Fix: Fix Upload error due to deprecated use of btoa

### DIFF
--- a/lumina/components/UploadComponent.tsx
+++ b/lumina/components/UploadComponent.tsx
@@ -1,14 +1,11 @@
 import { useNostr, useNostrEvents } from "nostr-react"
-import { finalizeEvent, nip19, type NostrEvent } from "nostr-tools"
+import { nip19, type NostrEvent } from "nostr-tools"
 import type React from "react"
 import { type ChangeEvent, type FormEvent, useState, useEffect, useCallback } from "react"
 import { Button } from "./ui/button"
 import { Textarea } from "./ui/textarea"
-import { bytesToHex, hexToBytes } from "@noble/hashes/utils"
 import { ReloadIcon } from "@radix-ui/react-icons"
-import { Label } from "./ui/label"
 import { Input } from "./ui/input"
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion"
 import { encode } from "blurhash"
 import {
   Drawer,
@@ -173,13 +170,15 @@ const UploadComponent: React.FC = () => {
         console.log(authEvent)
 
         // Sign auth event
-        let authEventSigned = (await signEvent(loginType, authEvent)) as NostrEvent
+        const authEventSigned = (await signEvent(loginType, authEvent)) as NostrEvent
+        // authEventSigned as base64 encoded string
+        let authString = Buffer.from(JSON.stringify(authEventSigned)).toString('base64')
 
         // Actually upload the file
         await fetch("https://nostr.download/upload", {
           method: "PUT",
           body: file,
-          headers: { authorization: "Nostr " + btoa(JSON.stringify(authEventSigned)) },
+          headers: { authorization: "Nostr " + authString },
         }).then(async (res) => {
           if (res.ok) {
             const responseText = await res.text()


### PR DESCRIPTION
This pull request includes several changes to the `UploadComponent` in the `lumina` project to improve code efficiency and readability. The main changes involve removing unused imports and refactoring the code for signing and uploading events.

Code cleanup and refactoring:

* [`lumina/components/UploadComponent.tsx`](diffhunk://#diff-89246ad9ad644b72ad98ef51afcaef51b4fee7c05c65279c6cb8fdb50859168cL2-L11): Removed unused imports such as `finalizeEvent`, `bytesToHex`, `hexToBytes`, `Label`, and `Accordion` components.
* `const UploadComponent: React.FC = () => {` in `lumina/components/UploadComponent.tsx`: Refactored the code to use `const` instead of `let` for `authEventSigned` and added a new variable `authString` to store the base64 encoded string of the signed event. This change simplifies the header assignment in the file upload request.