### PR TITLE
add NIP-89 client tag when posting

### DIFF
--- a/lumina/components/UploadComponent.tsx
+++ b/lumina/components/UploadComponent.tsx
@@ -217,6 +217,10 @@ const UploadComponent: React.FC = () => {
 
             const createdAt = Math.floor(Date.now() / 1000)
 
+            // NIP-89
+            // ["client","lumina","31990:ff363e4afc398b7dd8ceb0b2e73e96fe9621ababc22ab150ffbb1aa0f34df8b2:1731850618505"]
+            noteTags.push(["client", "lumina", "31990:" + "ff363e4afc398b7dd8ceb0b2e73e96fe9621ababc22ab150ffbb1aa0f34df8b2" + ":" + createdAt])
+            
             // Create the actual note
             const noteEvent: NostrEvent = {
               kind: 20,


### PR DESCRIPTION
This pull request includes a small change to the `UploadComponent` in the `lumina/components/UploadComponent.tsx` file. The change adds a new tag to the `noteTags` array.

* [`lumina/components/UploadComponent.tsx`](diffhunk://#diff-89246ad9ad644b72ad98ef51afcaef51b4fee7c05c65279c6cb8fdb50859168cR220-R223): Added a new tag to the `noteTags` array with the format `["client","lumina","31990:<pubkey>:<timestamp>"]` to comply with NIP-89.

https://github.com/nostr-protocol/nips/blob/master/89.md