### PR TITLE
Feature: Improve and Extend Dashboard Statistics

### DIFF
--- a/components/dashboard/Statistics.tsx
+++ b/components/dashboard/Statistics.tsx
@@ -16,6 +16,8 @@ interface ProfileInfoCardProps {
 }
 
 const ProfileInfoCard: React.FC<ProfileInfoCardProps> = ({ pubkey }) => {
+    var lightningPayReq = require('bolt11');
+
     const { data: userData, isLoading: userDataLoading } = useProfile({
         pubkey,
     });
@@ -27,12 +29,38 @@ const ProfileInfoCard: React.FC<ProfileInfoCardProps> = ({ pubkey }) => {
         },
     });
 
-    const { events: zaps, isLoading: zapsLoading } = useNostrEvents({
+    const { events: zapsReceived, isLoading: zapsReceivedLoading } = useNostrEvents({
         filter: {
             kinds: [9735],
             '#p': [pubkey],
-            limit: 50,
         },
+    });
+
+    const { events: zapsSent, isLoading: zapsSentLoading } = useNostrEvents({
+        filter: {
+            kinds: [9735],
+            authors: [pubkey],
+        },
+    });
+
+    let satsReceived = 0;
+    zapsReceived.forEach((event) => {
+        event.tags.forEach((tag) => {
+            if (tag[0] === 'bolt11') {
+                let decoded = lightningPayReq.decode(tag[1]);
+                satsReceived += decoded.satoshis;
+            }
+        });
+    });
+
+    let satsSent = 0;
+    zapsSent.forEach((event) => {
+        event.tags.forEach((tag) => {
+            if (tag[0] === 'bolt11') {
+                let decoded = lightningPayReq.decode(tag[1]);
+                satsSent += decoded.satoshis;
+            }
+        });
     });
 
     const { events: following, isLoading: followingLoading } = useNostrEvents({
@@ -110,8 +138,32 @@ const ProfileInfoCard: React.FC<ProfileInfoCardProps> = ({ pubkey }) => {
                         </p> */}
                     </CardContent>
                 </Card>
-                <RecentFollowerCard followers={filteredFollowers.reverse()} />
-                <RecentZapsCard zaps={zaps.reverse() ?? []} />
+                <Card>
+                    <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                        <CardTitle className="text-base font-normal">Zaps received</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <div className="text-2xl font-bold">{zapsReceived.length} zaps</div>
+                        <div className="text-xl">{satsReceived} sats</div>
+                        {/* <p className="text-xs text-muted-foreground">
+                            +20.1% from last month
+                        </p> */}
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                        <CardTitle className="text-base font-normal">Zaps sent</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <div className="text-2xl font-bold">{zapsSent.length} zaps</div>
+                        <div className="text-xl">{satsSent} sats</div>
+                        {/* <p className="text-xs text-muted-foreground">
+                            +20.1% from last month
+                        </p> */}
+                    </CardContent>
+                </Card>
+                {/* <RecentFollowerCard followers={filteredFollowers.reverse()} /> */}
+                <RecentZapsCard zaps={zapsReceived.reverse() ?? []} />
             </div>
         </>
     );

--- a/components/dashboard/Statistics.tsx
+++ b/components/dashboard/Statistics.tsx
@@ -116,7 +116,7 @@ const ProfileInfoCard: React.FC<ProfileInfoCardProps> = ({ pubkey }) => {
             <div className='grid gap-4 grid-cols-2 p-6'>
                 <Card>
                     <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                        <CardTitle className="text-base font-normal">Total Followers</CardTitle>
+                        <CardTitle className="text-base font-normal">Followers</CardTitle>
                     </CardHeader>
                     <CardContent>
                         <div className="text-2xl font-bold">{followers.length}</div>
@@ -127,7 +127,7 @@ const ProfileInfoCard: React.FC<ProfileInfoCardProps> = ({ pubkey }) => {
                 </Card>
                 <Card>
                     <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                        <CardTitle className="text-base font-normal">Total Following</CardTitle>
+                        <CardTitle className="text-base font-normal">Following</CardTitle>
                     </CardHeader>
                     <CardContent>
                         <div className="text-2xl font-bold">

--- a/components/dashboard/Statistics.tsx
+++ b/components/dashboard/Statistics.tsx
@@ -116,7 +116,7 @@ const ProfileInfoCard: React.FC<ProfileInfoCardProps> = ({ pubkey }) => {
             <div className='grid gap-4 grid-cols-2 p-6'>
                 <Card>
                     <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                        <CardTitle className="text-base font-normal">Followers</CardTitle>
+                        <CardTitle className="text-base font-normal">Followers 🫂</CardTitle>
                     </CardHeader>
                     <CardContent>
                         <div className="text-2xl font-bold">{followers.length}</div>
@@ -127,7 +127,7 @@ const ProfileInfoCard: React.FC<ProfileInfoCardProps> = ({ pubkey }) => {
                 </Card>
                 <Card>
                     <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                        <CardTitle className="text-base font-normal">Following</CardTitle>
+                        <CardTitle className="text-base font-normal">Following 🫂</CardTitle>
                     </CardHeader>
                     <CardContent>
                         <div className="text-2xl font-bold">
@@ -140,7 +140,7 @@ const ProfileInfoCard: React.FC<ProfileInfoCardProps> = ({ pubkey }) => {
                 </Card>
                 <Card>
                     <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                        <CardTitle className="text-base font-normal">Zaps received</CardTitle>
+                        <CardTitle className="text-base font-normal">Zaps received ⚡️</CardTitle>
                     </CardHeader>
                     <CardContent>
                         <div className="text-2xl font-bold">{zapsReceived.length} zaps</div>
@@ -152,7 +152,7 @@ const ProfileInfoCard: React.FC<ProfileInfoCardProps> = ({ pubkey }) => {
                 </Card>
                 <Card>
                     <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                        <CardTitle className="text-base font-normal">Zaps sent</CardTitle>
+                        <CardTitle className="text-base font-normal">Zaps sent ⚡️</CardTitle>
                     </CardHeader>
                     <CardContent>
                         <div className="text-2xl font-bold">{zapsSent.length} zaps</div>


### PR DESCRIPTION
This pull request includes several updates to the `ProfileInfoCard` component in `components/dashboard/Statistics.tsx` to enhance the display of user statistics, including zaps received and sent. The most important changes include adding new data fetching logic for zaps sent, calculating the total satoshis received and sent, and updating the UI to display this information.

Enhancements to data fetching and calculation:

* Added the `bolt11` library to decode lightning payment requests.
* Added fetching logic for zaps sent by the user and calculated the total satoshis sent and received using the `bolt11` library.

UI updates:

* Updated the card titles for followers and following to include emojis for better visual appeal. [[1]](diffhunk://#diff-a0ba5d2d68fbc66e115bd435c2f493dbdb13e4d15f90bf15c7ce901dd28d29fdL91-R119) [[2]](diffhunk://#diff-a0ba5d2d68fbc66e115bd435c2f493dbdb13e4d15f90bf15c7ce901dd28d29fdL102-R130)
* Added new cards to display the number of zaps received and sent, along with the total satoshis for each.