### PR TITLE
fix(ProfileTextFeed): correct filtering logic for text messages

### DIFF
--- a/components/ProfileTextFeed.tsx
+++ b/components/ProfileTextFeed.tsx
@@ -21,9 +21,9 @@ const ProfileTextFeed: React.FC<ProfileTextFeedProps> = ({ pubkey }) => {
   });
 
   // filter out all images since we only want text messages
-  let filteredEvents = events.filter((event) => !event.content.match(/https?:\/\/.*\.(?:png|jpg|gif|jpeg)/g)?.[0]);
+  // let filteredEvents = events.filter((event) => !event.content.match(/https?:\/\/.*\.(?:png|jpg|gif|jpeg)/g)?.[0]);
   // filter out all replies (tag[0] == e)
-  filteredEvents = filteredEvents.filter((event) => !event.tags.some((tag) => { return tag[0] == 'e' }));
+  let filteredEvents = events.filter((event) => !event.tags.some((tag) => { return tag[0] == 'e' }));
 
   const loadMore = () => {
     setLimit(prevLimit => prevLimit + 10);


### PR DESCRIPTION
This pull request includes a change to the `ProfileTextFeed` component in the `components/ProfileTextFeed.tsx` file. The change modifies how events are filtered to exclude replies and potentially includes a commented-out line that previously filtered out image URLs.

Filtering logic update:

* [`components/ProfileTextFeed.tsx`](diffhunk://#diff-f6522601134e161e2a19b6a1c4e8b03f4fea7925b84bf1134636d00c9e94a629L24-R26): Commented out the line that filters out image URLs and updated the filtering logic to only exclude replies based on the presence of tags.