### PR TITLE
add github button to the top Navbar

### DIFF
--- a/components/headerComponents/GitHubButton.tsx
+++ b/components/headerComponents/GitHubButton.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { Github } from "lucide-react"
+import Link from "next/link"
+
+interface GitHubButtonProps {
+  repoUrl?: string
+}
+
+export default function GitHubButton({ repoUrl = "https://github.com/lumina-rocks/lumina" }: GitHubButtonProps) {
+  return (
+    <Link href={repoUrl} target="_blank" rel="noopener noreferrer">
+      <Button variant="outline" size="icon" aria-label="View GitHub Repository">
+        <Github className="h-[1.2rem] w-[1.2rem]" />
+      </Button>
+    </Link>
+  )
+}
+

--- a/components/headerComponents/TopNavigation.tsx
+++ b/components/headerComponents/TopNavigation.tsx
@@ -1,22 +1,22 @@
-"use client";
+"use client"
 
-import { siteConfig } from "@/config/site";
-import { useEffect, useState } from "react";
-import { TopNavigationItems } from "./TopNavigationItems";
-import { DropdownThemeMode } from "./DropdownThemeMode";
-import LoginButton from "./LoginButton";
-import { Button } from "../ui/button";
-import { AvatarDropdown } from "./AvatarDropdown";
-import RegisterButton from "./RegisterButton";
+import { siteConfig } from "@/config/site"
+import { useEffect, useState } from "react"
+import { TopNavigationItems } from "./TopNavigationItems"
+import { DropdownThemeMode } from "./DropdownThemeMode"
+import LoginButton from "./LoginButton"
+import { AvatarDropdown } from "./AvatarDropdown"
+import RegisterButton from "./RegisterButton"
+import GitHubButton from "@/components/headerComponents/GitHubButton"
 
 export function TopNavigation() {
-  const [pubkey, setPubkey] = useState<string | null>(null);
-  const [mounted, setMounted] = useState(false);
+  const [pubkey, setPubkey] = useState<string | null>(null)
+  const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
-    setMounted(true);
-    setPubkey(window.localStorage.getItem('pubkey'));
-  }, []);
+    setMounted(true)
+    setPubkey(window.localStorage.getItem("pubkey"))
+  }, [])
 
   // Prevent hydration mismatch by not rendering auth-dependent content until mounted
   if (!mounted) {
@@ -26,12 +26,13 @@ export function TopNavigation() {
           <TopNavigationItems items={siteConfig.mainNav} />
           <div className="flex flex-1 items-center justify-end space-x-4">
             <nav className="flex items-center space-x-2">
+              <GitHubButton />
               <DropdownThemeMode />
             </nav>
           </div>
         </div>
       </header>
-    );
+    )
   }
 
   return (
@@ -40,6 +41,7 @@ export function TopNavigation() {
         <TopNavigationItems items={siteConfig.mainNav} />
         <div className="flex flex-1 items-center justify-end space-x-4">
           <nav className="flex items-center space-x-2">
+            <GitHubButton />
             <DropdownThemeMode />
             {pubkey === null ? <RegisterButton /> : null}
             {pubkey === null ? <LoginButton /> : null}
@@ -50,3 +52,4 @@ export function TopNavigation() {
     </header>
   )
 }
+


### PR DESCRIPTION
This pull request introduces a new `GitHubButton` component and integrates it into the `TopNavigation` component. The changes include the creation of the `GitHubButton` component and its usage in the `TopNavigation` component to provide a link to the GitHub repository.

New component addition:

* [`components/headerComponents/GitHubButton.tsx`](diffhunk://#diff-22bdf5eb71361dac55b3e01110e4626b282be3bbd9b9b148c0b61dfd4486ab7dR1-R20): Added a new `GitHubButton` component that links to the GitHub repository.

Integration into existing component:

* [`components/headerComponents/TopNavigation.tsx`](diffhunk://#diff-d9bb7a05b9f1435c8a424c65d44408f0c0599e9d08d0678f8bd7f11b9eef919bL1-R19): Imported and added the `GitHubButton` component to the `TopNavigation` component. [[1]](diffhunk://#diff-d9bb7a05b9f1435c8a424c65d44408f0c0599e9d08d0678f8bd7f11b9eef919bL1-R19) [[2]](diffhunk://#diff-d9bb7a05b9f1435c8a424c65d44408f0c0599e9d08d0678f8bd7f11b9eef919bR29-R35) [[3]](diffhunk://#diff-d9bb7a05b9f1435c8a424c65d44408f0c0599e9d08d0678f8bd7f11b9eef919bR44) [[4]](diffhunk://#diff-d9bb7a05b9f1435c8a424c65d44408f0c0599e9d08d0678f8bd7f11b9eef919bR55)