### PR TITLE
change default blossom server to blossom.primal.net

### DIFF
--- a/components/UploadComponent.tsx
+++ b/components/UploadComponent.tsx
@@ -304,8 +304,9 @@ const UploadComponent: React.FC = () => {
                 <SelectValue placeholder={serverChoice} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="nostr.download">nostr.download</SelectItem>
                 <SelectItem value="blossom.primal.net">blossom.primal.net</SelectItem>
+                <SelectItem value="media.lumina.rocks">media.lumina.rocks</SelectItem>
+                <SelectItem value="nostr.download">nostr.download</SelectItem>
               </SelectContent>
             </Select>
           </div>

--- a/components/UploadComponent.tsx
+++ b/components/UploadComponent.tsx
@@ -59,7 +59,7 @@ const UploadComponent: React.FC = () => {
   const [uploadedNoteId, setUploadedNoteId] = useState("")
   const [retryCount, setRetryCount] = useState(0)
   const [shouldFetch, setShouldFetch] = useState(false)
-  const [serverChoice, setServerChoice] = useState("nostr.download")
+  const [serverChoice, setServerChoice] = useState("blossom.primal.net")
 
   const { events, isLoading: isNoteLoading } = useNostrEvents({
     filter: shouldFetch


### PR DESCRIPTION
This pull request includes updates to the `UploadComponent` in `components/UploadComponent.tsx` to change the default server choice and modify the available server options in the selection dropdown.

Changes in server configuration:

* Updated the default server choice from `nostr.download` to `blossom.primal.net`.
* Modified the server selection dropdown to include `media.lumina.rocks` and reordered the options.