### PR TITLE
refactor KIND20Card image container for responsive height adjustments

### DIFF
--- a/components/KIND20Card.tsx
+++ b/components/KIND20Card.tsx
@@ -80,14 +80,29 @@ const KIND20Card: React.FC<KIND20CardProps> = ({
           <CardContent className="p-0">
             <div className="px-2 sm:px-4">
               <div className="w-full">
-                <div className="relative w-full" style={{ paddingBottom: "100%" }}>
-                  <Image
-                    src={image}
-                    alt={text}
-                    fill
-                    className="rounded-lg object-contain"
-                    onError={() => setImageError(true)}
-                  />
+                {/* Modified image container with max-height for desktop */}
+                <div className="relative w-full sm:max-h-[500px] md:max-h-[600px]">
+                  {/* On mobile, keep original square aspect ratio, on desktop limit height */}
+                  <div className="block sm:hidden relative w-full" style={{ paddingBottom: "100%" }}>
+                    <Image
+                      src={image}
+                      alt={text}
+                      fill
+                      className="rounded-lg object-contain"
+                      onError={() => setImageError(true)}
+                    />
+                  </div>
+                  {/* Desktop version with constrained height */}
+                  <div className="hidden sm:block w-full h-full max-h-[600px]">
+                    <Image
+                      src={image}
+                      alt={text}
+                      width={1200}
+                      height={800}
+                      className="rounded-lg object-contain w-full h-auto max-h-[600px]"
+                      onError={() => setImageError(true)}
+                    />
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
This pull request includes modifications to the `KIND20Card` component to improve the image display for different screen sizes. The changes ensure that the image container has a constrained height on desktop devices while maintaining the original aspect ratio on mobile devices.

Improvements to image display:

* [`components/KIND20Card.tsx`](diffhunk://#diff-24739b501b35807433c3765aad2957d1383de9db4e6b282ed16a908d34877e16L83-R86): Modified the image container to include a maximum height for desktop screens, ensuring a better layout by using different styles for mobile and desktop views.
* [`components/KIND20Card.tsx`](diffhunk://#diff-24739b501b35807433c3765aad2957d1383de9db4e6b282ed16a908d34877e16R95-R106): Added a new desktop version of the image with constrained height and specific dimensions to enhance the display on larger screens.