### PR TITLE
add comments fetching and filtering to CommentCard and CommentsComponent

### DIFF
--- a/components/CommentCard.tsx
+++ b/components/CommentCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useProfile } from "nostr-react";
+import { useProfile, useNostrEvents } from "nostr-react";
 import {
   nip19,
 } from "nostr-tools";
@@ -40,6 +40,14 @@ interface CommentCardProps {
 const NoteCard: React.FC<CommentCardProps> = ({ pubkey, text, eventId, tags, event }) => {
   const { data: userData } = useProfile({
     pubkey,
+  });
+  
+  // Fetch comments related to this event
+  const { events: commentEvents } = useNostrEvents({
+    filter: {
+      kinds: [1],
+      '#e': [eventId],
+    },
   });
 
   const title = userData?.username || userData?.display_name || userData?.name || userData?.npub || nip19.npubEncode(pubkey);
@@ -111,6 +119,29 @@ const NoteCard: React.FC<CommentCardProps> = ({ pubkey, text, eventId, tags, eve
             </div>
             <ViewRawButton event={event} />
           </div>
+          
+          {/* Comments section */}
+          {commentEvents && commentEvents.length > 0 && (
+            <div className="mt-4">
+              {/* <h3 className="text-lg font-medium mb-2">Comments ({commentEvents.length})</h3> */}
+              <div className="space-y-3">
+                {commentEvents.map((commentEvent) => (
+                  // <div key={commentEvent.id} className="border p-3 rounded-md">
+                  //   <div className="flex items-center mb-2">
+                  //     <span className="text-sm font-medium">
+                  //       {nip19.npubEncode(commentEvent.pubkey).substring(0, 10)}...
+                  //     </span>
+                  //     <span className="text-xs ml-2 text-gray-500">
+                  //       {new Date(commentEvent.created_at * 1000).toLocaleString()}
+                  //     </span>
+                  //   </div>
+                  //   <p className="text-sm">{commentEvent.content}</p>
+                  // </div>
+                  <NoteCard key={commentEvent.id} pubkey={commentEvent.pubkey} text={commentEvent.content} eventId={commentEvent.id} tags={commentEvent.tags} event={commentEvent} />
+                ))}
+              </div>
+            </div>
+          )}
         </CardContent>
         <CardFooter>
           <small className="text-muted">{createdAt.toLocaleString()}</small>

--- a/components/CommentsCompontent.tsx
+++ b/components/CommentsCompontent.tsx
@@ -19,7 +19,7 @@ const CommentsCompontent: React.FC<CommentsCompontentProps> = ({ pubkey, event }
         },
     });
 
-    // filter out all events with more then 1 "e" tag. other tags are ok
+    // filter out all events with more than 1 "e" tag. other tags are ok
     // this shows only the top level comments
     let filteredEvents = events.filter((event) => {
         return event.tags.filter((tag) => tag[0] === 'e').length === 1;

--- a/components/CommentsCompontent.tsx
+++ b/components/CommentsCompontent.tsx
@@ -19,10 +19,16 @@ const CommentsCompontent: React.FC<CommentsCompontentProps> = ({ pubkey, event }
         },
     });
 
+    // filter out all events with more then 1 "e" tag. other tags are ok
+    // this shows only the top level comments
+    let filteredEvents = events.filter((event) => {
+        return event.tags.filter((tag) => tag[0] === 'e').length === 1;
+    });
+
     return (
         <>
             <h1 className='text-xl'>Comments</h1>
-            {events.map((event) => (
+            {filteredEvents.map((event) => (
                 <div key={event.id} className="py-6">
                     <CommentCard key={event.id} pubkey={event.pubkey} text={event.content} eventId={event.id} tags={event.tags} event={event} />
                 </div>


### PR DESCRIPTION
This pull request introduces several enhancements to the comments feature in the `components/CommentCard.tsx` and `components/CommentsCompontent.tsx` files. The main improvements include fetching and displaying related comments for events and filtering top-level comments.

Enhancements to comments feature:

* [`components/CommentCard.tsx`](diffhunk://#diff-1965b6d3dc8c270fc41e4af15444ce453d4cacad9730e6f62a4098d66b391751L2-R2): Imported `useNostrEvents` to fetch comments related to the event.
* [`components/CommentCard.tsx`](diffhunk://#diff-1965b6d3dc8c270fc41e4af15444ce453d4cacad9730e6f62a4098d66b391751R45-R52): Added logic to fetch and display comments related to the event using the `useNostrEvents` hook. [[1]](diffhunk://#diff-1965b6d3dc8c270fc41e4af15444ce453d4cacad9730e6f62a4098d66b391751R45-R52) [[2]](diffhunk://#diff-1965b6d3dc8c270fc41e4af15444ce453d4cacad9730e6f62a4098d66b391751R122-R144)
* [`components/CommentsCompontent.tsx`](diffhunk://#diff-e361ec6d059b4fceaf6fa6e06f9d2a8e59f9d64fc6bd4d7389ed1d0f2b2aaf47R22-R31): Implemented a filter to show only top-level comments by filtering out events with more than one "e" tag.