### PR TITLE
Feature: Add NIP-65 (Load User Relays)

### DIFF
--- a/.github/prompts/nostr-nip65.prompt.md
+++ b/.github/prompts/nostr-nip65.prompt.md
@@ -1,0 +1,42 @@
+NIP-65
+======
+
+Relay List Metadata
+-------------------
+
+`draft` `optional`
+
+Defines a replaceable event using `kind:10002` to advertise relays where the user generally **writes** to and relays where the user generally **reads** mentions.
+
+The event MUST include a list of `r` tags with relay URLs as value and an optional `read` or `write` marker. If the marker is omitted, the relay is both **read** and **write**.
+
+```jsonc
+{
+  "kind": 10002,
+  "tags": [
+    ["r", "wss://alicerelay.example.com"],
+    ["r", "wss://brando-relay.com"],
+    ["r", "wss://expensive-relay.example2.com", "write"],
+    ["r", "wss://nostr-relay.example.com", "read"]
+  ],
+  "content": "",
+  // other fields...
+}
+```
+
+When downloading events **from** a user, clients SHOULD use the **write** relays of that user.
+
+When downloading events **about** a user, where the user was tagged (mentioned), clients SHOULD use the user's **read** relays.
+
+When publishing an event, clients SHOULD:
+
+- Send the event to the **write** relays of the author
+- Send the event to all **read** relays of each tagged user
+
+### Size
+
+Clients SHOULD guide users to keep `kind:10002` lists small (2-4 relays of each category).
+
+### Discoverability
+
+Clients SHOULD spread an author's `kind:10002` event to as many relays as viable, paying attention to relays that, at any moment, serve naturally as well-known public indexers for these relay lists (where most other clients and users are connecting to in order to publish and fetch those).

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -24,7 +24,7 @@ import {
 import { useEffect, useRef, useState } from "react"
 import { getPublicKey, generateSecretKey, nip19, SimplePool } from 'nostr-tools'
 import { BunkerSigner, parseBunkerInput } from 'nostr-tools/nip46'
-import { InfoIcon } from "lucide-react";
+import { InfoIcon, Loader2 } from "lucide-react";
 import Link from "next/link";
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils'
 import { fetchNip65Relays, mergeAndStoreRelays } from "@/utils/nip65Utils"
@@ -36,6 +36,11 @@ export function LoginForm() {
     let npubInput = useRef<HTMLInputElement>(null);
     let bunkerUrlInput = useRef<HTMLInputElement>(null);
     const [isLoading, setIsLoading] = useState(false);
+    const [isBunkerLoading, setIsBunkerLoading] = useState(false);
+    const [isExtensionLoading, setIsExtensionLoading] = useState(false);
+    const [isAmberLoading, setIsAmberLoading] = useState(false);
+    const [isNsecLoading, setIsNsecLoading] = useState(false);
+    const [isNpubLoading, setIsNpubLoading] = useState(false);
     const [bunkerError, setBunkerError] = useState<string | null>(null);
 
     // Default relays to query for NIP-65 data
@@ -66,16 +71,27 @@ export function LoginForm() {
 
     // Function to complete login process
     const completeLogin = async (pubkey: string, loginType: string, redirect = true) => {
-        // Store the login info
-        localStorage.setItem("pubkey", pubkey);
-        localStorage.setItem("loginType", loginType);
-        
-        // Load NIP-65 relays
-        await loadNip65Relays(pubkey);
-        
-        // Redirect if needed
-        if (redirect) {
-            window.location.href = `/profile/${nip19.npubEncode(pubkey)}`;
+        try {
+            // Store the login info
+            localStorage.setItem("pubkey", pubkey);
+            localStorage.setItem("loginType", loginType);
+            
+            // Load NIP-65 relays
+            await loadNip65Relays(pubkey);
+            
+            // Redirect if needed
+            if (redirect) {
+                window.location.href = `/profile/${nip19.npubEncode(pubkey)}`;
+            }
+        } catch (error) {
+            console.error("Error completing login:", error);
+            // Reset all loading states in case of error
+            setIsLoading(false);
+            setIsBunkerLoading(false);
+            setIsExtensionLoading(false);
+            setIsAmberLoading(false);
+            setIsNsecLoading(false);
+            setIsNpubLoading(false);
         }
     };
 
@@ -84,6 +100,7 @@ export function LoginForm() {
         const urlParams = new URLSearchParams(window.location.search);
         const amberResponse = urlParams.get('amberResponse');
         if (amberResponse !== null) {
+            setIsAmberLoading(true);
             completeLogin(amberResponse, "amber");
         }
 
@@ -97,6 +114,7 @@ export function LoginForm() {
     const handleNostrConnect = async (url: string) => {
         try {
             setIsLoading(true);
+            setIsBunkerLoading(true);
             setBunkerError(null);
             
             // Generate local secret key for communicating with the bunker
@@ -136,10 +154,12 @@ export function LoginForm() {
                 setBunkerError("Failed to connect to bunker. Please check the URL and try again.");
                 await bunker.close().catch(console.error);
                 pool.close([]);
+                setIsBunkerLoading(false);
             }
         } catch (err) {
             console.error("Bunker parsing error:", err);
             setBunkerError("Invalid bunker URL format.");
+            setIsBunkerLoading(false);
         } finally {
             setIsLoading(false);
         }
@@ -155,46 +175,52 @@ export function LoginForm() {
     };
 
     const handleAmber = async () => {
-        const hostname = window.location.host;
-        console.log(hostname);
-        if (!hostname) {
-            throw new Error("Hostname is null or undefined");
+        try {
+            setIsAmberLoading(true);
+            setIsLoading(true);
+            const hostname = window.location.host;
+            console.log(hostname);
+            if (!hostname) {
+                throw new Error("Hostname is null or undefined");
+            }
+            const intent = `intent:#Intent;scheme=nostrsigner;S.compressionType=none;S.returnType=signature;S.type=get_public_key;S.callbackUrl=http://${hostname}/login?amberResponse=;end`;
+            window.location.href = intent;
+            // The loading state will be maintained until the callback returns or page unloads
+        } catch (error) {
+            console.error("Error launching Amber:", error);
+            setIsAmberLoading(false);
+            setIsLoading(false);
         }
-        const intent = `intent:#Intent;scheme=nostrsigner;S.compressionType=none;S.returnType=signature;S.type=get_public_key;S.callbackUrl=http://${hostname}/login?amberResponse=;end`;
-        window.location.href = intent;
-        // window.location.href = `nostrsigner:?compressionType=none&returnType=signature&type=get_public_key&callbackUrl=http://${hostname}/login?amberResponse=`;
     }
 
     const handleExtensionLogin = async () => {
-        // eslint-disable-next-line
-        if (window.nostr !== undefined) {
-            publicKey.current = await window.nostr.getPublicKey()
-            console.log("Logged in with pubkey: ", publicKey.current);
-            if (publicKey.current !== null) {
-                await completeLogin(publicKey.current, "extension");
+        try {
+            setIsExtensionLoading(true);
+            setIsLoading(true);
+            // eslint-disable-next-line
+            if (window.nostr !== undefined) {
+                publicKey.current = await window.nostr.getPublicKey()
+                console.log("Logged in with pubkey: ", publicKey.current);
+                if (publicKey.current !== null) {
+                    await completeLogin(publicKey.current, "extension");
+                } else {
+                    throw new Error("Failed to get public key from extension");
+                }
+            } else {
+                throw new Error("Nostr extension not detected");
             }
+        } catch (error) {
+            console.error("Extension login error:", error);
+            setIsExtensionLoading(false);
+            setIsLoading(false);
         }
     };
-
-    // const handleNsecSignUp = async () => {
-    //     let nsec = generateSecretKey();
-    //     console.log('nsec: ' + nsec);
-
-    //     let nsecHex = bytesToHex(nsec);
-    //     console.log('bytesToHex nsec: ' + nsecHex);
-
-    //     let pubkey = getPublicKey(nsec);
-    //     console.log('pubkey: ' + pubkey);
-
-    //     localStorage.setItem("nsec", nsecHex);
-    //     localStorage.setItem("pubkey", pubkey);
-    //     localStorage.setItem("loginType", "raw_nsec")
-    //     window.location.href = `/profile/${nip19.npubEncode(pubkey)}`;
-    // };
 
     const handleNsecLogin = async () => {
         if (nsecInput.current !== null) {
             try {
+                setIsNsecLoading(true);
+                setIsLoading(true);
                 let input = nsecInput.current.value;
                 if(input.includes("nsec")) {
                     input = bytesToHex(nip19.decode(input).data as Uint8Array);
@@ -208,6 +234,8 @@ export function LoginForm() {
                 await completeLogin(pubkey, "raw_nsec");
             } catch (e) {
                 console.error(e);
+                setIsNsecLoading(false);
+                setIsLoading(false);
             }
         }
     };
@@ -215,6 +243,8 @@ export function LoginForm() {
     const handleNpubLogin = async () => {
         if (npubInput.current !== null) {
             try {
+                setIsNpubLoading(true);
+                setIsLoading(true);
                 let input = npubInput.current.value;
                 let npub = null;
                 let pubkey = null;
@@ -229,6 +259,8 @@ export function LoginForm() {
                 await completeLogin(pubkey, "readOnly_npub");
             } catch (e) {
                 console.error(e);
+                setIsNpubLoading(false);
+                setIsLoading(false);
             }
         }
     };
@@ -243,15 +275,37 @@ export function LoginForm() {
             </CardHeader>
             <CardContent className="grid gap-4">
                 <div className="grid grid-cols-8 gap-2">
-                    <Button className="w-full col-span-7" onClick={handleExtensionLogin}>Sign in with Extension (NIP-07)</Button>
+                    <Button 
+                        className="w-full col-span-7" 
+                        onClick={handleExtensionLogin} 
+                        disabled={isLoading || isExtensionLoading}
+                    >
+                        {isExtensionLoading ? (
+                            <>
+                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                Connecting...
+                            </>
+                        ) : "Sign in with Extension (NIP-07)"}
+                    </Button>
                     <Link target="_blank" href="https://www.getflamingo.org/">
-                        <Button variant={"outline"}><InfoIcon /></Button>
+                        <Button variant={"outline"} disabled={isLoading}><InfoIcon /></Button>
                     </Link>
                 </div>
                 <div className="grid grid-cols-8 gap-2">
-                    <Button className="w-full col-span-7" onClick={handleAmber}>Sign in with Amber</Button>
+                    <Button 
+                        className="w-full col-span-7" 
+                        onClick={handleAmber} 
+                        disabled={isLoading || isAmberLoading}
+                    >
+                        {isAmberLoading ? (
+                            <>
+                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                Connecting...
+                            </>
+                        ) : "Sign in with Amber"}
+                    </Button>
                     <Link target="_blank" href="https://github.com/greenart7c3/Amber">
-                        <Button variant={"outline"}><InfoIcon /></Button>
+                        <Button variant={"outline"} disabled={isLoading}><InfoIcon /></Button>
                     </Link>
                 </div>
                 <hr />
@@ -262,15 +316,25 @@ export function LoginForm() {
                         <AccordionContent>
                             <div className="grid gap-2">
                                 <Label htmlFor="bunkerUrl">Bunker URL</Label>
-                                <Input placeholder="bunker://... or nostrconnect://..." 
-                                       id="bunkerUrl" 
-                                       ref={bunkerUrlInput} 
-                                       type="text" />
+                                <Input 
+                                    placeholder="bunker://... or nostrconnect://..." 
+                                    id="bunkerUrl" 
+                                    ref={bunkerUrlInput} 
+                                    type="text"
+                                    disabled={isLoading || isBunkerLoading} 
+                                />
                                 {bunkerError && <p className="text-red-500 text-sm">{bunkerError}</p>}
-                                <Button className="w-full" 
-                                        onClick={handleBunkerLogin} 
-                                        disabled={isLoading}>
-                                    {isLoading ? "Connecting..." : "Sign in with Bunker"}
+                                <Button 
+                                    className="w-full" 
+                                    onClick={handleBunkerLogin} 
+                                    disabled={isLoading || isBunkerLoading}
+                                >
+                                    {isBunkerLoading ? (
+                                        <>
+                                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                            Connecting...
+                                        </>
+                                    ) : "Sign in with Bunker"}
                                 </Button>
                                 <p className="text-sm text-muted-foreground">
                                     Use a NIP-46 compatible bunker URL that starts with bunker:// or nostrconnect://
@@ -286,9 +350,26 @@ export function LoginForm() {
                         <AccordionContent>
                             <div className="grid gap-2">
                                 <Label htmlFor="npub">npub</Label>
-                                <Input placeholder="npub1..." id="npub" ref={npubInput} type="text" />
-                                <Button className="w-full" onClick={handleNpubLogin}>Sign in</Button>
-                                </div>
+                                <Input 
+                                    placeholder="npub1..." 
+                                    id="npub" 
+                                    ref={npubInput} 
+                                    type="text" 
+                                    disabled={isLoading || isNpubLoading}
+                                />
+                                <Button 
+                                    className="w-full" 
+                                    onClick={handleNpubLogin}
+                                    disabled={isLoading || isNpubLoading}
+                                >
+                                    {isNpubLoading ? (
+                                        <>
+                                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                            Signing in...
+                                        </>
+                                    ) : "Sign in"}
+                                </Button>
+                            </div>
                         </AccordionContent>
                     </AccordionItem>
                 </Accordion>
@@ -299,9 +380,26 @@ export function LoginForm() {
                         <AccordionContent>
                             <div className="grid gap-2">
                                 <Label htmlFor="nsec">nsec</Label>
-                                <Input placeholder="nsecabcdefghijklmnopqrstuvwxyz" id="nsec" ref={nsecInput} type="password" />
-                                <Button className="w-full" onClick={handleNsecLogin}>Sign in</Button>
-                                </div>
+                                <Input 
+                                    placeholder="nsecabcdefghijklmnopqrstuvwxyz" 
+                                    id="nsec" 
+                                    ref={nsecInput} 
+                                    type="password" 
+                                    disabled={isLoading || isNsecLoading}
+                                />
+                                <Button 
+                                    className="w-full" 
+                                    onClick={handleNsecLogin}
+                                    disabled={isLoading || isNsecLoading}
+                                >
+                                    {isNsecLoading ? (
+                                        <>
+                                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                            Signing in...
+                                        </>
+                                    ) : "Sign in"}
+                                </Button>
+                            </div>
                         </AccordionContent>
                     </AccordionItem>
                 </Accordion>

--- a/utils/nip65Utils.ts
+++ b/utils/nip65Utils.ts
@@ -1,0 +1,99 @@
+import { SimplePool, Filter, Event } from 'nostr-tools';
+
+// Interface for NIP-65 relay with read/write permissions
+export interface Nip65Relay {
+  url: string;
+  read: boolean;
+  write: boolean;
+}
+
+/**
+ * Fetches NIP-65 relay list metadata for a specific user
+ * @param pubkey User's public key
+ * @param relays Relays to query for NIP-65 events
+ * @returns Object with parsed relay permissions
+ */
+export async function fetchNip65Relays(pubkey: string, relays: string[]): Promise<Nip65Relay[]> {
+  // Create a pool for temporary use
+  const pool = new SimplePool();
+  
+  try {
+    // Define filter for NIP-65 events (kind:10002)
+    const filter: Filter = {
+      kinds: [10002],
+      authors: [pubkey],
+      limit: 1, // We only need the most recent one
+    };
+    
+    // Fetch the event (pool.get returns a single event or undefined)
+    const latestEvent = await pool.get(relays, filter);
+
+    if (!latestEvent) {
+      return [];
+    }
+
+    // Parse the relay tags
+    return parseNip65Event(latestEvent);
+  } catch (error) {
+    console.error('Error fetching NIP-65 relays:', error);
+    return [];
+  } finally {
+    // Close the pool to clean up connections
+    pool.close(relays);
+  }
+}
+
+/**
+ * Parses a NIP-65 event and extracts relay information
+ * @param event NIP-65 event (kind:10002)
+ * @returns Array of relays with read/write permissions
+ */
+export function parseNip65Event(event: Event): Nip65Relay[] {
+  if (event.kind !== 10002) {
+    return [];
+  }
+  
+  const relays: Nip65Relay[] = [];
+  
+  // Process each 'r' tag
+  for (const tag of event.tags) {
+    if (tag[0] === 'r' && tag[1]) {
+      const url = tag[1];
+      const permission = tag[2]?.toLowerCase();
+      
+      // Default is both read and write if no permission specified
+      relays.push({
+        url,
+        read: permission ? permission.includes('read') : true,
+        write: permission ? permission.includes('write') : true
+      });
+    }
+  }
+  
+  return relays;
+}
+
+/**
+ * Merges NIP-65 relays with existing custom relays and stores in localStorage
+ * @param nip65Relays NIP-65 relays to merge
+ */
+export function mergeAndStoreRelays(nip65Relays: Nip65Relay[]): string[] {
+  try {
+    // Get existing custom relays
+    const existingRelays = JSON.parse(localStorage.getItem("customRelays") || "[]");
+    
+    // Extract URLs from NIP-65 relays (we'll add all relays for now, both read and write)
+    const nip65RelayUrls = nip65Relays.map(relay => relay.url);
+    
+    // Merge existing and NIP-65 relays, removing duplicates
+    const mergedRelays = Array.from(new Set([...existingRelays, ...nip65RelayUrls]));
+    
+    // Store updated list
+    localStorage.setItem("customRelays", JSON.stringify(mergedRelays));
+    
+    return mergedRelays;
+  } catch (error) {
+    console.error('Error merging relays:', error);
+    return [];
+  }
+}


### PR DESCRIPTION
This pull request introduces support for NIP-65 relay list metadata in the application, enabling users to manage and refresh their preferred relay connections more effectively. The changes span new utility functions, updates to the relay management UI, and integration into the login process.

### NIP-65 Relay Support

* Added a detailed explanation of NIP-65 relay list metadata in `.github/prompts/nostr-nip65.prompt.md`, including the structure, usage guidelines, and client behavior recommendations.

### Relay Management Enhancements

* Updated `RelaysPage` (`app/relays/page.tsx`) to include:
  - A "Refresh NIP-65 Relays" button for fetching and updating relay preferences. [[1]](diffhunk://#diff-dfe0abe96494ef06d8bb97afa13043304b2f38281f2fdfaa5780f5613a46b8a4R47-R103) [[2]](diffhunk://#diff-dfe0abe96494ef06d8bb97afa13043304b2f38281f2fdfaa5780f5613a46b8a4R145-R157)
  - A new section explaining NIP-65 relay lists and their integration into the application.
  - Improved button labels for clarity, e.g., "Refresh Connection Status."

### Login Process Integration

* Modified `LoginForm` (`components/LoginForm.tsx`) to:
  - Fetch and merge NIP-65 relays during login using a new helper function.
  - Centralize login completion logic into a `completeLogin` function, ensuring NIP-65 relay updates occur consistently across login methods. [[1]](diffhunk://#diff-d5d11b7b99020962c832b8cc41a4650f9350e168b7acbd0050fec0fc4e7cb339L86-R133) [[2]](diffhunk://#diff-d5d11b7b99020962c832b8cc41a4650f9350e168b7acbd0050fec0fc4e7cb339L136-R174) [[3]](diffhunk://#diff-d5d11b7b99020962c832b8cc41a4650f9350e168b7acbd0050fec0fc4e7cb339L173-R208) [[4]](diffhunk://#diff-d5d11b7b99020962c832b8cc41a4650f9350e168b7acbd0050fec0fc4e7cb339L197-L207)

### Utility Functions for NIP-65

* Introduced `utils/nip65Utils.ts` with the following functions:
  - [`fetchNip65Relays`](diffhunk://#diff-03806b7dbc81643a10d7886e30423883bb7aaec56fdd3d986323159d40897671R1-R99): Fetches NIP-65 relay metadata for a user from specified relays.
  - [`parseNip65Event`](diffhunk://#diff-03806b7dbc81643a10d7886e30423883bb7aaec56fdd3d986323159d40897671R1-R99): Parses NIP-65 events to extract relay permissions.
  - [`mergeAndStoreRelays`](diffhunk://#diff-03806b7dbc81643a10d7886e30423883bb7aaec56fdd3d986323159d40897671R1-R99): Merges fetched relays with existing ones and stores them in local storage.