### PR TITLE
Feature: Change to /upload Blossom Endpoint + Strip Metadata in Client

### DIFF
--- a/components/UploadComponent.tsx
+++ b/components/UploadComponent.tsx
@@ -59,9 +59,13 @@ async function stripImageMetadata(file: File): Promise<File> {
       }, file.type)
     }
 
-    img.onerror = () => reject(new Error("Failed to load image"))
-    img.src = URL.createObjectURL(file)
-  })
+    img.onerror = () => {
+      URL.revokeObjectURL(objectUrl)
+      reject(new Error("Failed to load image"))
+    }
+    const objectUrl = URL.createObjectURL(file)
+    img.src = objectUrl
+    img.onload = () => URL.revokeObjectURL(objectUrl)
 }
 
 async function calculateBlurhash(file: File): Promise<string> {

--- a/components/UploadComponent.tsx
+++ b/components/UploadComponent.tsx
@@ -27,6 +27,8 @@ import { Switch } from "@/components/ui/switch"
 async function stripImageMetadata(file: File): Promise<File> {
   return new Promise((resolve, reject) => {
     const img = new Image()
+    const objectUrl = URL.createObjectURL(file)
+    
     img.onload = () => {
       // Create a canvas to draw the image without metadata
       const canvas = document.createElement("canvas")
@@ -36,6 +38,7 @@ async function stripImageMetadata(file: File): Promise<File> {
       // Draw the image onto the canvas (this strips the metadata)
       const ctx = canvas.getContext("2d")
       if (!ctx) {
+        URL.revokeObjectURL(objectUrl)
         reject(new Error("Failed to get canvas context"))
         return
       }
@@ -44,6 +47,9 @@ async function stripImageMetadata(file: File): Promise<File> {
 
       // Convert canvas back to a file
       canvas.toBlob((blob) => {
+        // Clean up the object URL
+        URL.revokeObjectURL(objectUrl)
+        
         if (!blob) {
           reject(new Error("Failed to create blob from canvas"))
           return
@@ -63,9 +69,9 @@ async function stripImageMetadata(file: File): Promise<File> {
       URL.revokeObjectURL(objectUrl)
       reject(new Error("Failed to load image"))
     }
-    const objectUrl = URL.createObjectURL(file)
+    
     img.src = objectUrl
-    img.onload = () => URL.revokeObjectURL(objectUrl)
+  })
 }
 
 async function calculateBlurhash(file: File): Promise<string> {

--- a/components/UploadComponent.tsx
+++ b/components/UploadComponent.tsx
@@ -353,9 +353,15 @@ const UploadComponent: React.FC = () => {
             id="description"
             className="w-full"
           ></Textarea>
-          <div className="grid w-full max-w-sm items-center gap-1.5">
-            <Input id="file" name="file" type="file" accept="image/*" onChange={handleFileChange} />
-          </div>
+            <div className="grid w-full max-w-sm items-center gap-1.5">
+            <Input
+              id="file"
+              name="file"
+              type="file"
+              accept="image/jpeg,image/png,image/webp"
+              onChange={handleFileChange}
+            />
+            </div>
           <div className="grid grid-cols-2 w-full max-w-sm items-center gap-1.5">
             {/* <select value={serverChoice} onChange={handleServerChange} className="w-full">
               <option value="nostr.download">nostr.download</option>


### PR DESCRIPTION
This pull request introduces functionality to strip metadata from uploaded image files, modifies the upload process to accommodate this change, and updates the tagging and endpoint logic for file uploads. Below is a summary of the most important changes:

### Metadata Stripping for Image Files:
* Added a new `stripImageMetadata` function to remove metadata from image files by rendering them onto a canvas and converting the result back into a file. (`components/UploadComponent.tsx`, [components/UploadComponent.tsxR26-R66](diffhunk://#diff-8994966607e6b80f3e2a4a3f7ff3d9b6caebec639071027bd3e473cc9c397c65R26-R66))
* Updated the file upload process to use the `stripImageMetadata` function before proceeding with further processing. (`components/UploadComponent.tsx`, [components/UploadComponent.tsxR197-R199](diffhunk://#diff-8994966607e6b80f3e2a4a3f7ff3d9b6caebec639071027bd3e473cc9c397c65R197-R199))

### Upload Process Modifications:
* Changed the `file` variable from `const` to `let` to allow reassignment after metadata stripping. (`components/UploadComponent.tsx`, [components/UploadComponent.tsxL126-R167](diffhunk://#diff-8994966607e6b80f3e2a4a3f7ff3d9b6caebec639071027bd3e473cc9c397c65L126-R167))
* Updated the upload endpoint from `/media` to `/upload` to reflect changes in the backend API. (`components/UploadComponent.tsx`, [components/UploadComponent.tsxL193-R239](diffhunk://#diff-8994966607e6b80f3e2a4a3f7ff3d9b6caebec639071027bd3e473cc9c397c65L193-R239))

### Tagging Adjustments:
* Replaced the `["t", "media"]` tag with `["t", "upload"]` to better describe the file upload process. (`components/UploadComponent.tsx`, [components/UploadComponent.tsxL175-R220](diffhunk://#diff-8994966607e6b80f3e2a4a3f7ff3d9b6caebec639071027bd3e473cc9c397c65L175-R220))