### PR TITLE
Feature: Add refresh button to relays in UploadComponent

### DIFF
--- a/components/UploadComponent.tsx
+++ b/components/UploadComponent.tsx
@@ -22,6 +22,7 @@ import { signEvent } from "@/utils/utils"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
+import { RefreshCw } from "lucide-react"
 
 // Function to strip metadata from image files
 async function stripImageMetadata(file: File): Promise<File> {
@@ -422,9 +423,19 @@ const UploadComponent: React.FC = () => {
           </DrawerHeader>
           <DrawerFooter className="flex flex-col space-y-2">
             {events.length === 0 && (
-              <Button onClick={handleRetry} variant="outline" className="w-full">
-                Retry Now
-              </Button>
+              <>
+                <Button onClick={handleRetry} variant="outline" className="w-full">
+                  Retry Now
+                </Button>
+                <Button 
+                  onClick={() => window.location.reload()} 
+                  variant="outline" 
+                  className="w-full flex items-center gap-2"
+                >
+                  <RefreshCw className="h-4 w-4" />
+                  Refresh Relays
+                </Button>
+              </>
             )}
             <Button asChild className="w-full">
               <a href={`/note/${nip19.noteEncode(uploadedNoteId)}`}>View Note</a>


### PR DESCRIPTION
This pull request introduces a new button to refresh relays in the `UploadComponent` and adds an icon from the `lucide-react` library to enhance the UI. Below are the key changes:

### UI Enhancements:

* Added a new "Refresh Relays" button in the `DrawerFooter` of the `UploadComponent`. The button uses the `RefreshCw` icon from the `lucide-react` library and reloads the page when clicked.

### Library Import:

* Imported the `RefreshCw` icon from the `lucide-react` library to support the new button in the `UploadComponent`.