### PR TITLE
Feature: Update Profile Info Card

### DIFF
--- a/components/ProfileInfoCard.tsx
+++ b/components/ProfileInfoCard.tsx
@@ -20,8 +20,9 @@ import {
   DrawerTrigger,
 } from "@/components/ui/drawer"
 import { Input } from './ui/input';
-import { Share1Icon, LightningBoltIcon } from '@radix-ui/react-icons';
+import { Share1Icon, LightningBoltIcon, GlobeIcon } from '@radix-ui/react-icons';
 import { toast } from './ui/use-toast';
+import { Globe } from 'lucide-react';
 
 interface ProfileInfoCardProps {
   pubkey: string;
@@ -48,6 +49,7 @@ const ProfileInfoCard: React.FC<ProfileInfoCardProps> = React.memo(({ pubkey }) 
   const description = userData?.about?.replace(/(?:\r\n|\r|\n)/g, '<br>');
   const nip05 = userData?.nip05;
   const lightningAddress = userData?.lud16;
+  const website = userData?.website;
 
   const handleCopyLink = async () => {
     try {
@@ -99,6 +101,18 @@ const ProfileInfoCard: React.FC<ProfileInfoCardProps> = React.memo(({ pubkey }) 
     }
   };
 
+  const handleOpenWebsite = () => {
+    if (!website) return;
+    
+    // Add https:// prefix if not present
+    let url = website;
+    if (!/^https?:\/\//i.test(url)) {
+      url = 'https://' + url;
+    }
+    
+    window.open(url, '_blank');
+  };
+
   return (
     <div className='py-6'>
       <Card>
@@ -115,9 +129,15 @@ const ProfileInfoCard: React.FC<ProfileInfoCardProps> = React.memo(({ pubkey }) 
                 <NIP05 nip05={nip05?.toString() ?? ''} pubkey={pubkey} />
               </div>
               {lightningAddress && (
-                <div className="text-sm text-muted-foreground flex items-center gap-1 cursor-pointer" onClick={handleCopyLightningAddress}>
+                <div className="text-sm text-muted-foreground flex items-center gap-1 cursor-pointer hover:text-purple-400 transition-colors" onClick={handleCopyLightningAddress}>
                   <LightningBoltIcon className="h-4 w-4 text-yellow-500" />
                   <span>{lightningAddress}</span>
+                </div>
+              )}
+              {website && (
+                <div className="text-sm text-muted-foreground flex items-center gap-1 cursor-pointer hover:text-purple-400 transition-colors" onClick={handleOpenWebsite}>
+                  <Globe className="h-4 w-4 text-purple-500" />
+                  <span>{website}</span>
                 </div>
               )}
             </div>

--- a/components/ProfileInfoCard.tsx
+++ b/components/ProfileInfoCard.tsx
@@ -20,7 +20,7 @@ import {
   DrawerTrigger,
 } from "@/components/ui/drawer"
 import { Input } from './ui/input';
-import { Share1Icon } from '@radix-ui/react-icons';
+import { Share1Icon, LightningBoltIcon } from '@radix-ui/react-icons';
 import { toast } from './ui/use-toast';
 
 interface ProfileInfoCardProps {
@@ -47,6 +47,7 @@ const ProfileInfoCard: React.FC<ProfileInfoCardProps> = React.memo(({ pubkey }) 
   const title = userData?.username || userData?.display_name || userData?.name || userData?.npub || npubShortened;
   const description = userData?.about?.replace(/(?:\r\n|\r|\n)/g, '<br>');
   const nip05 = userData?.nip05;
+  const lightningAddress = userData?.lud16;
 
   const handleCopyLink = async () => {
     try {
@@ -80,6 +81,24 @@ const ProfileInfoCard: React.FC<ProfileInfoCardProps> = React.memo(({ pubkey }) 
     }
   };
 
+  const handleCopyLightningAddress = async () => {
+    if (!lightningAddress) return;
+    
+    try {
+      await navigator.clipboard.writeText(lightningAddress);
+      toast({
+        description: 'Lightning Address copied to clipboard',
+        title: 'Copied'
+      });
+    } catch (err) {
+      toast({
+        description: 'Error copying Lightning Address to clipboard',
+        title: 'Error',
+        variant: 'destructive'
+      });
+    }
+  };
+
   return (
     <div className='py-6'>
       <Card>
@@ -95,6 +114,12 @@ const ProfileInfoCard: React.FC<ProfileInfoCardProps> = React.memo(({ pubkey }) 
               <div className="text-sm text-muted-foreground">
                 <NIP05 nip05={nip05?.toString() ?? ''} pubkey={pubkey} />
               </div>
+              {lightningAddress && (
+                <div className="text-sm text-muted-foreground flex items-center gap-1 cursor-pointer" onClick={handleCopyLightningAddress}>
+                  <LightningBoltIcon className="h-4 w-4 text-yellow-500" />
+                  <span>{lightningAddress}</span>
+                </div>
+              )}
             </div>
           </div>
           <div>

--- a/components/nip05.tsx
+++ b/components/nip05.tsx
@@ -1,4 +1,5 @@
 import { CheckIcon, ReloadIcon } from "@radix-ui/react-icons";
+import { BadgeCheck, Check } from "lucide-react";
 import React, { useState, useEffect } from 'react';
 
 interface NIP05Props {
@@ -33,8 +34,14 @@ const NIP05: React.FC<NIP05Props> = ({ nip05, pubkey }) => {
             <div style={{ display: 'flex', alignItems: 'center' }}>
                 {nip05.length > 0 && 
                 <>
+                    {isLoading ? (
+                        <ReloadIcon className="mr-1 h-4 w-4 animate-spin" />
+                    ) : isValid ? (
+                        <BadgeCheck className="mr-1 h-4 w-4 text-blue-500" />
+                    ) : (
+                        <span className="mr-1 text-red-500">❌</span>
+                    )}
                     { name === "_" ? domain : nip05 }
-                    {isLoading ? <ReloadIcon className="mx-2 h-4 w-4 animate-spin" /> : isValid ? <CheckIcon className="mx-2 h-4 w-4" /> : <span className="mx-2 text-red-500">❌</span>}
                 </>
                 }
             </div>


### PR DESCRIPTION
This pull request enhances the `ProfileInfoCard` and `NIP05` components by adding support for displaying and copying a Lightning Address and improving the visual feedback for NIP-05 validation. Below are the most important changes:

### Enhancements to `ProfileInfoCard` Component:
* Added a new `lightningAddress` field to display a Lightning Address if available. This includes rendering the address with a `LightningBoltIcon` and a click-to-copy functionality. [[1]](diffhunk://#diff-1d417d73ff86573ea14d1615dcafb892b83bc751ba313fb7b8c4318a5c14b357R50) [[2]](diffhunk://#diff-1d417d73ff86573ea14d1615dcafb892b83bc751ba313fb7b8c4318a5c14b357R117-R122)
* Implemented a `handleCopyLightningAddress` function to copy the Lightning Address to the clipboard with success and error feedback using the `toast` utility.
* Imported `LightningBoltIcon` from `@radix-ui/react-icons` for use in the Lightning Address UI.

### Improvements to `NIP05` Component:
* Replaced `CheckIcon` with `BadgeCheck` from `lucide-react` for a more modern design in NIP-05 validation feedback. [[1]](diffhunk://#diff-73adabad6b4099ca45849e8ca7fc4aec78528b2e3cf6261da0249c5832a34f1bR2) [[2]](diffhunk://#diff-73adabad6b4099ca45849e8ca7fc4aec78528b2e3cf6261da0249c5832a34f1bR37-L37)
* Enhanced the loading and validation states with improved icons and animations, including a spinning `ReloadIcon` during validation and a blue `BadgeCheck` for valid states.