### PR TITLE
Feature: Show Kind1 Pictures on Account Page

### DIFF
--- a/components/ProfileFeed.tsx
+++ b/components/ProfileFeed.tsx
@@ -12,12 +12,12 @@ interface ProfileFeedProps {
 
 const ProfileFeed: React.FC<ProfileFeedProps> = ({ pubkey }) => {
   const now = useRef(new Date());
-  const [limit, setLimit] = useState(10);
+  const [limit, setLimit] = useState(100);
 
   const { events, isLoading } = useNostrEvents({
     filter: {
       authors: [pubkey],
-      kinds: [20],
+      kinds: [1, 20],
       limit: limit,
     },
   });

--- a/components/ProfileQuickViewFeed.tsx
+++ b/components/ProfileQuickViewFeed.tsx
@@ -11,13 +11,13 @@ interface ProfileQuickViewFeedProps {
 
 const ProfileQuickViewFeed: React.FC<ProfileQuickViewFeedProps> = ({ pubkey }) => {
   const now = useRef(new Date()); // Make sure current time isn't re-rendered
-  const [limit, setLimit] = useState(20);
+  const [limit, setLimit] = useState(100);
 
   const { isLoading, events } = useNostrEvents({
     filter: {
       authors: [pubkey],
       limit: limit,
-      kinds: [20],
+      kinds: [1, 20],
     },
   });
 


### PR DESCRIPTION
This pull request updates the feed components to increase the number of events fetched and expand the types of events displayed. The changes primarily affect the `ProfileFeed` and `ProfileQuickViewFeed` components.

### Changes to event fetching behavior:

* [`components/ProfileFeed.tsx`](diffhunk://#diff-74d7294b940b31f8ea06462729eb47a1dc96f7d0d84f2ae3b1e684f199f0ba6bL15-R20): Increased the default `limit` for events from 10 to 100 and updated the `kinds` filter to include both type `1` and type `20` events.
* [`components/ProfileQuickViewFeed.tsx`](diffhunk://#diff-1785fcbd59197dfcb5409713cde57a903475c8976acd106c55eb18f61f6cf211L14-R20): Increased the default `limit` for events from 20 to 100 and updated the `kinds` filter to include both type `1` and type `20` events.