### PR TITLE
Feature: Display site version in Top Navigation

### DIFF
--- a/components/headerComponents/TopNavigationItems.tsx
+++ b/components/headerComponents/TopNavigationItems.tsx
@@ -16,6 +16,9 @@ export function TopNavigationItems({ items }: TopNavigationItemsProps) {
       <Link href="/" className="flex items-center space-x-2">
         {/* <Icons.logo className="h-6 w-6" /> */}
         <span className="inline-block font-bold">{siteConfig.name}</span>
+        <span className="inline-flex items-center rounded-md bg-muted px-2 py-1 text-xs font-medium text-muted-foreground">
+          v{siteConfig.version}
+        </span>
       </Link>
       {/* TOP NAVIGATION ITEMS */}
       {/* {items?.length ? (

--- a/config/site.ts
+++ b/config/site.ts
@@ -1,7 +1,11 @@
+// Import package information dynamically
+import packageInfo from "../package.json"
+
 export type SiteConfig = typeof siteConfig
 
 export const siteConfig = {
   name: "LUMINA",
+  version: packageInfo.version, // Use the version from package.json
   description:
     "A beautiful Nostr client for images.",
   mainNav: [


### PR DESCRIPTION
This pull request enhances the header component to display the application version dynamically and updates the site configuration to retrieve the version from `package.json`.

### Header Component Update:
* [`components/headerComponents/TopNavigationItems.tsx`](diffhunk://#diff-fda06249bc1c26838b44079548ba85e9a52f9d9a253b5edd97b6ae2df94b61fcR19-R21): Added a new span element to display the app version (`v{siteConfig.version}`) next to the site name in the top navigation bar.

### Site Configuration Update:
* [`config/site.ts`](diffhunk://#diff-76ee19096ae53cfcae6e36f792ab8c5e883b129403a99c1dda6ec76b75d3be23R1-R8): Imported version information from `package.json` and added a `version` property to the `siteConfig` object to make the version accessible throughout the application.