### PR TITLE
feat: Add text change handler to replace specific Lumina links

### DIFF
--- a/components/UploadComponent.tsx
+++ b/components/UploadComponent.tsx
@@ -178,8 +178,10 @@ const UploadComponent: React.FC = () => {
     // Replace https://lumina.rocks/note/note1... with "nostr:note1..."
     updatedValue = updatedValue.replace(/https:\/\/lumina\.rocks\/note\/(note[1-9a-zA-Z]{0,64})/g, "nostr:$1");
     
-    // Update the state with the modified value
-    setTextValue(updatedValue);
+    // Update the textarea with the modified value
+    event.target.value = updatedValue;
+    
+    return updatedValue
   }
 
   const handleServerChange = (value: string) => {

--- a/components/UploadComponent.tsx
+++ b/components/UploadComponent.tsx
@@ -178,10 +178,8 @@ const UploadComponent: React.FC = () => {
     // Replace https://lumina.rocks/note/note1... with "nostr:note1..."
     updatedValue = updatedValue.replace(/https:\/\/lumina\.rocks\/note\/(note[1-9a-zA-Z]{0,64})/g, "nostr:$1");
     
-    // Update the textarea with the modified value
-    event.target.value = updatedValue;
-    
-    return updatedValue
+    // Update the state with the modified value
+    setTextValue(updatedValue);
   }
 
   const handleServerChange = (value: string) => {

--- a/components/UploadComponent.tsx
+++ b/components/UploadComponent.tsx
@@ -166,6 +166,24 @@ const UploadComponent: React.FC = () => {
     }
   }
 
+  const handleTextChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    const { value } = event.target
+
+    // Replace links only if they contain https://lumina.rocks
+    let updatedValue = value;
+    
+    // Replace https://lumina.rocks/profile/npub1... with "nostr:npub1..."
+    updatedValue = updatedValue.replace(/https:\/\/lumina\.rocks\/profile\/(npub[1-9a-zA-Z]{0,64})/g, "nostr:$1");
+    
+    // Replace https://lumina.rocks/note/note1... with "nostr:note1..."
+    updatedValue = updatedValue.replace(/https:\/\/lumina\.rocks\/note\/(note[1-9a-zA-Z]{0,64})/g, "nostr:$1");
+    
+    // Update the textarea with the modified value
+    event.target.value = updatedValue;
+    
+    return updatedValue
+  }
+
   const handleServerChange = (value: string) => {
     setServerChoice(value)
   }
@@ -361,6 +379,7 @@ const UploadComponent: React.FC = () => {
                 placeholder="What's on your mind? Add #hashtags to categorize your post."
                 id="description"
                 className="w-full resize-none"
+                onChange={handleTextChange}
               />
             </div>
             


### PR DESCRIPTION
This pull request introduces a new feature to the `UploadComponent` in `components/UploadComponent.tsx` that automatically replaces specific URLs with a custom format in the textarea input. It also integrates this feature by attaching the new handler to the `onChange` event of the textarea.

### New Feature: URL Replacement in Textarea
* Added a `handleTextChange` function to process textarea input and replace URLs containing `https://lumina.rocks/profile/npub...` with `nostr:npub...` and `https://lumina.rocks/note/note...` with `nostr:note...`. This ensures that specific URLs are converted into a custom format for further processing.
* Updated the textarea element to use the `handleTextChange` function via the `onChange` event, enabling real-time URL transformation as the user types or pastes content.