### PR TITLE
fix: Adjust Load More button placement in ProfileFeed and ProfileTextFeed

### DIFF
--- a/components/ProfileFeed.tsx
+++ b/components/ProfileFeed.tsx
@@ -54,11 +54,6 @@ const ProfileFeed: React.FC<ProfileFeedProps> = ({ pubkey }) => {
                 />
               ) : null;
             })}
-            {!isLoading && (
-              <div className="flex justify-center p-4">
-                <Button className="w-full md:w-auto" onClick={loadMore}>Load More</Button>
-              </div>
-            )}
           </>
         ) : (
           <div className="flex flex-col items-center justify-center py-10 text-gray-500">
@@ -66,6 +61,11 @@ const ProfileFeed: React.FC<ProfileFeedProps> = ({ pubkey }) => {
           </div>
         )}
       </div>
+      {!isLoading && (
+        <div className="flex justify-center p-4">
+          <Button className="w-full" onClick={loadMore}>Load More</Button>
+        </div>
+      )}
     </>
   );
 }

--- a/components/ProfileTextFeed.tsx
+++ b/components/ProfileTextFeed.tsx
@@ -55,14 +55,14 @@ const ProfileTextFeed: React.FC<ProfileTextFeedProps> = ({ pubkey }) => {
                 />
               </div>
             ))}
-            {!isLoading && filteredEvents.length > 0 && (
-              <div className="flex justify-center p-4">
-                <Button className="w-full md:w-auto" onClick={loadMore}>Load More</Button>
-              </div>
-            )}
           </>
         )}
       </div>
+      {!isLoading && filteredEvents.length > 0 && (
+        <div className="flex justify-center p-4">
+          <Button className="w-full" onClick={loadMore}>Load More</Button>
+        </div>
+      )}
     </>
   );
 }


### PR DESCRIPTION
This pull request makes adjustments to the "Load More" button placement and styling in two components, `ProfileFeed` and `ProfileTextFeed`, to improve consistency and user experience.

**Changes to button placement and styling:**

* [`components/ProfileFeed.tsx`](diffhunk://#diff-74d7294b940b31f8ea06462729eb47a1dc96f7d0d84f2ae3b1e684f199f0ba6bL57-R68): Moved the "Load More" button outside the conditional rendering block for improved layout consistency and removed the `md:w-auto` class to standardize the button width.
* [`components/ProfileTextFeed.tsx`](diffhunk://#diff-f6522601134e161e2a19b6a1c4e8b03f4fea7925b84bf1134636d00c9e94a629R58-L66): Adjusted the "Load More" button styling by removing the `md:w-auto` class for consistent width and simplified the conditional rendering structure.