### PR TITLE
Feature: NIP-09 Event Deletion Request

### DIFF
--- a/.github/prompts/nostr-nip09.prompt.md
+++ b/.github/prompts/nostr-nip09.prompt.md
@@ -1,0 +1,53 @@
+NIP-09
+======
+
+Event Deletion Request
+----------------------
+
+`draft` `optional`
+
+A special event with kind `5`, meaning "deletion request" is defined as having a list of one or more `e` or `a` tags, each referencing an event the author is requesting to be deleted. Deletion requests SHOULD include a `k` tag for the kind of each event being requested for deletion.
+
+The event's `content` field MAY contain a text note describing the reason for the deletion request.
+
+For example:
+
+```jsonc
+{
+  "kind": 5,
+  "pubkey": <32-bytes hex-encoded public key of the event creator>,
+  "tags": [
+    ["e", "dcd59..464a2"],
+    ["e", "968c5..ad7a4"],
+    ["a", "<kind>:<pubkey>:<d-identifier>"],
+    ["k", "1"],
+    ["k", "30023"]
+  ],
+  "content": "these posts were published by accident",
+  // other fields...
+}
+```
+
+Relays SHOULD delete or stop publishing any referenced events that have an identical `pubkey` as the deletion request.  Clients SHOULD hide or otherwise indicate a deletion request status for referenced events.
+
+Relays SHOULD continue to publish/share the deletion request events indefinitely, as clients may already have the event that's intended to be deleted. Additionally, clients SHOULD broadcast deletion request events to other relays which don't have it.
+
+When an `a` tag is used, relays SHOULD delete all versions of the replaceable event up to the `created_at` timestamp of the deletion request event.
+
+## Client Usage
+
+Clients MAY choose to fully hide any events that are referenced by valid deletion request events.  This includes text notes, direct messages, or other yet-to-be defined event kinds.  Alternatively, they MAY show the event along with an icon or other indication that the author has "disowned" the event.  The `content` field MAY also be used to replace the deleted events' own content, although a user interface should clearly indicate that this is a deletion request reason, not the original content.
+
+A client MUST validate that each event `pubkey` referenced in the `e` tag of the deletion request is identical to the deletion request `pubkey`, before hiding or deleting any event.  Relays can not, in general, perform this validation and should not be treated as authoritative.
+
+Clients display the deletion request event itself in any way they choose, e.g., not at all, or with a prominent notice.
+
+Clients MAY choose to inform the user that their request for deletion does not guarantee deletion because it is impossible to delete events from all relays and clients.
+
+## Relay Usage
+
+Relays MAY validate that a deletion request event only references events that have the same `pubkey` as the deletion request itself, however this is not required since relays may not have knowledge of all referenced events.
+
+## Deletion Request of a Deletion Request
+
+Publishing a deletion request event against a deletion request has no effect.  Clients and relays are not obliged to support "unrequest deletion" functionality.

--- a/components/CardOptionsDropdown.tsx
+++ b/components/CardOptionsDropdown.tsx
@@ -96,6 +96,14 @@ export default function CardOptionsDropdown({ event }: CardOptionsDropdownProps)
         }
 
         const loginType = window.localStorage.getItem('loginType');
+        if (!loginType) {
+            toast({
+                description: 'Login type is missing. Please log in again.',
+                title: 'Error',
+                variant: 'destructive'
+            });
+            return;
+        }
 
         // Create a kind 5 event (deletion request) as per NIP-09
         const deletionEvent: NostrEvent = {

--- a/components/KIND20Card.tsx
+++ b/components/KIND20Card.tsx
@@ -142,7 +142,7 @@ const KIND20Card: React.FC<KIND20CardProps> = ({
                               src={imageUrl}
                               alt={text}
                               className="rounded-lg w-full h-auto object-contain"
-                              onError={() => handleImageError(imageUrl)}
+                              // onError={() => handleImageError(imageUrl)}
                               loading="lazy"
                               style={{
                                 maxHeight: "80vh",

--- a/components/QuickViewKind20NoteCard.tsx
+++ b/components/QuickViewKind20NoteCard.tsx
@@ -44,7 +44,7 @@ const QuickViewKind20NoteCard: React.FC<QuickViewKind20NoteCardProps> = ({ pubke
               alt={text}
               className='w-full h-full rounded lg:rounded-lg object-cover' 
               loading="lazy"
-              onError={() => setImageError(true)}
+              // onError={() => setImageError(true)}
               style={{ objectPosition: 'center' }}
             />
           </div>


### PR DESCRIPTION
This pull request introduces support for NIP-09 deletion requests, allowing users to request the deletion of their events, and includes some minor code adjustments. The primary changes involve implementing the deletion request functionality in the UI and backend logic, as well as updating documentation to describe the behavior. Additionally, some error-handling code for image rendering has been commented out.

### NIP-09 Deletion Request Implementation

* **Documentation Update**: Added a detailed explanation of NIP-09 deletion requests in `.github/prompts/nostr-nip09.prompt.md`. This includes the structure of deletion request events, client and relay behavior, and usage guidelines.
* **UI Changes in `CardOptionsDropdown`**:
  - Added a "Request Deletion" option to the dropdown menu, visible only to the event owner.
  - Implemented a deletion request drawer with a text area for specifying the reason for deletion and a note explaining the limitations of deletion requests.
  - Added logic to validate the user's ownership of the event and to create, sign, and publish a deletion request event.
* **Imports and State Updates**: Added necessary imports (`Trash2`, `useNostr`, `signEvent`) and state variables (`deleteDrawerOpen`, `deleteReason`) to support the new functionality. [[1]](diffhunk://#diff-b47df23bbdeb47e66de57058be3b9dd3a741207f4fe1c4ecbfadcb1953df856dR25-R27) [[2]](diffhunk://#diff-b47df23bbdeb47e66de57058be3b9dd3a741207f4fe1c4ecbfadcb1953df856dR38-R43)

### Minor Adjustments

* **Image Error Handling**: Commented out error-handling code for image rendering in `KIND20Card.tsx` and `QuickViewKind20NoteCard.tsx`. [[1]](diffhunk://#diff-24739b501b35807433c3765aad2957d1383de9db4e6b282ed16a908d34877e16L145-R145) [[2]](diffhunk://#diff-9c6d12c67d79c99829ced983f8796c7bc8269138eea1c4c87033bf4db5b0c53eL47-R47)