### PR TITLE
feat: Show "Follows you" when logged in

### DIFF
--- a/.github/prompts/nostr-nip02.prompt.md
+++ b/.github/prompts/nostr-nip02.prompt.md
@@ -1,0 +1,78 @@
+NIP-02
+======
+
+Follow List
+-----------
+
+`final` `optional`
+
+A special event with kind `3`, meaning "follow list" is defined as having a list of `p` tags, one for each of the followed/known profiles one is following.
+
+Each tag entry should contain the key for the profile, a relay URL where events from that key can be found (can be set to an empty string if not needed), and a local name (or "petname") for that profile (can also be set to an empty string or not provided), i.e., `["p", <32-bytes hex key>, <main relay URL>, <petname>]`.
+
+The `.content` is not used.
+
+For example:
+
+```jsonc
+{
+  "kind": 3,
+  "tags": [
+    ["p", "91cf9..4e5ca", "wss://alicerelay.com/", "alice"],
+    ["p", "14aeb..8dad4", "wss://bobrelay.com/nostr", "bob"],
+    ["p", "612ae..e610f", "ws://carolrelay.com/ws", "carol"]
+  ],
+  "content": "",
+  // other fields...
+}
+```
+
+Every new following list that gets published overwrites the past ones, so it should contain all entries. Relays and clients SHOULD delete past following lists as soon as they receive a new one.
+
+Whenever new follows are added to an existing list, clients SHOULD append them to the end of the list, so they are stored in chronological order.
+
+## Uses
+
+### Follow list backup
+
+If one believes a relay will store their events for sufficient time, they can use this kind-3 event to backup their following list and recover on a different device.
+
+### Profile discovery and context augmentation
+
+A client may rely on the kind-3 event to display a list of followed people by profiles one is browsing; make lists of suggestions on who to follow based on the follow lists of other people one might be following or browsing; or show the data in other contexts.
+
+### Relay sharing
+
+A client may publish a follow list with good relays for each of their follows so other clients may use these to update their internal relay lists if needed, increasing censorship-resistance.
+
+### Petname scheme
+
+The data from these follow lists can be used by clients to construct local ["petname"](http://www.skyhunter.com/marcs/petnames/IntroPetNames.html) tables derived from other people's follow lists. This alleviates the need for global human-readable names. For example:
+
+A user has an internal follow list that says
+
+```json
+[
+  ["p", "21df6d143fb96c2ec9d63726bf9edc71", "", "erin"]
+]
+```
+
+And receives two follow lists, one from `21df6d143fb96c2ec9d63726bf9edc71` that says
+
+```json
+[
+  ["p", "a8bb3d884d5d90b413d9891fe4c4e46d", "", "david"]
+]
+```
+
+and another from `a8bb3d884d5d90b413d9891fe4c4e46d` that says
+
+```json
+[
+  ["p", "f57f54057d2a7af0efecc8b0b66f5708", "", "frank"]
+]
+```
+
+When the user sees `21df6d143fb96c2ec9d63726bf9edc71` the client can show _erin_ instead;
+When the user sees `a8bb3d884d5d90b413d9891fe4c4e46d` the client can show _david.erin_ instead;
+When the user sees `f57f54057d2a7af0efecc8b0b66f5708` the client can show _frank.david.erin_ instead.

--- a/components/ProfileInfoCard.tsx
+++ b/components/ProfileInfoCard.tsx
@@ -238,9 +238,16 @@ const ProfileInfoCard: React.FC<ProfileInfoCardProps> = React.memo(({ pubkey }) 
       <Card>
         <CardHeader>
           <div className="flex items-center gap-6">
-            <Avatar className="h-24 w-24">
-              <AvatarImage className="object-cover w-full h-full" src={userData?.picture} alt={title} />
-            </Avatar>
+            <div className="relative">
+              <Avatar className={`h-24 w-24 ${userPubkey && userPubkey !== pubkey && isFollowingUser ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''}`}>
+                <AvatarImage className="object-cover w-full h-full" src={userData?.picture} alt={title} />
+              </Avatar>
+              {userPubkey && userPubkey !== pubkey && isFollowingUser && (
+                <div className="absolute -top-1 -right-1 bg-primary text-primary-foreground rounded-full p-1" title="Follows you">
+                  <UserCheck className="h-4 w-4" />
+                </div>
+              )}
+            </div>
             <div className="flex flex-col gap-1.5">
               <Link href={`/profile/${nip19.npubEncode(pubkey)}`}>
                 <div className="text-2xl">{title}</div>
@@ -248,12 +255,6 @@ const ProfileInfoCard: React.FC<ProfileInfoCardProps> = React.memo(({ pubkey }) 
               <div className="text-sm text-muted-foreground">
                 <NIP05 nip05={nip05?.toString() ?? ''} pubkey={pubkey} />
               </div>
-              {userPubkey && userPubkey !== pubkey && isFollowingUser && (
-                <div className="text-xs text-muted-foreground flex items-center gap-1">
-                  <UserCheck className="h-4 w-4 text-primary" />
-                  <span className="text-primary">Follows you</span>
-                </div>
-              )}
               {lightningAddress && (
                 <div className="text-sm text-muted-foreground flex items-center gap-1 cursor-pointer hover:text-purple-400 transition-colors" onClick={handleCopyLightningAddress}>
                   <LightningBoltIcon className="h-4 w-4 text-yellow-500" />

--- a/components/ProfileInfoCard.tsx
+++ b/components/ProfileInfoCard.tsx
@@ -244,7 +244,7 @@ const ProfileInfoCard: React.FC<ProfileInfoCardProps> = React.memo(({ pubkey }) 
               </Avatar>
               {userPubkey && userPubkey !== pubkey && isFollowingUser && (
                 <div className="absolute -top-1 -right-1 bg-primary text-primary-foreground rounded-full p-1" title="Follows you">
-                  <UserCheck className="h-4 w-4" />
+                  <UserCheck className="h-4 w-4" aria-label='Follows you' />
                 </div>
               )}
             </div>


### PR DESCRIPTION
This pull request introduces support for NIP-02 "follow list" events, which allow for better profile discovery and context augmentation in the application. The changes include adding a detailed prompt for NIP-02, updating the `ProfileInfoCard` component to fetch and process follow list events, and displaying a "Follows you" indicator if the profile owner follows the logged-in user.

### NIP-02 Follow List Support:

* **NIP-02 Prompt**: Added a detailed description of NIP-02 follow list events in `.github/prompts/nostr-nip02.prompt.md`. The prompt explains the structure, usage, and potential applications of follow list events, including follow list backups, profile discovery, relay sharing, and petname schemes.

### Updates to `ProfileInfoCard`:

* **Icon Import**: Added the `UserCheck` icon from `lucide-react` to be used for the "Follows you" indicator.
* **Follow List Fetching**: Integrated a new hook in `ProfileInfoCard` to fetch NIP-02 follow list events for the profile owner. The logic checks if the profile owner follows the logged-in user by analyzing the `p` tags in the follow list.
* **"Follows You" Indicator**: Added a visual indicator to the profile card, showing "Follows you" with an icon if the profile owner follows the logged-in user. This is displayed only when the logged-in user is different from the profile owner.